### PR TITLE
feat: CoffeeACIcon をロゴとしてヘッダー・トップページに追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { Check, LayoutDashboard, TableProperties } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Header } from "@/components/Header";
 import { UserIdForm } from "@/components/UserIdForm";
+import { CoffeeACIcon } from "@/components/CoffeeACIcon";
 import { TableView } from "@/components/TableView";
 import { Dashboard } from "@/components/Dashboard";
 import { FocusModal } from "@/components/FocusModal";
@@ -58,7 +59,14 @@ export default function Home() {
       <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4">
         {/* サービス紹介 */}
         <div className="text-center space-y-3 max-w-sm">
-          <h1 className="text-3xl font-bold tracking-tight">Next - AC</h1>
+          <div className="flex flex-col items-center gap-2">
+            <CoffeeACIcon size={72} />
+            <h1 className="text-3xl font-bold tracking-tight">
+              <span className="text-slate-800 dark:text-slate-100">Next</span>
+              <span className="text-slate-400 mx-1">-</span>
+              <span className="text-[#2ecc71]">AC</span>
+            </h1>
+          </div>
           <p className="text-lg font-medium">
             精進に、迷いはいらない。
           </p>

--- a/src/components/CoffeeACIcon.tsx
+++ b/src/components/CoffeeACIcon.tsx
@@ -1,0 +1,45 @@
+interface Props {
+  size?: number;
+  className?: string;
+}
+
+export function CoffeeACIcon({ size = 100, className = "" }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      {/* カップ本体 */}
+      <path
+        d="M30 40H70V65C70 76.0457 61.0457 85 50 85C38.9543 85 30 76.0457 30 65V40Z"
+        fill="#334155"
+      />
+      {/* 取っ手 */}
+      <path
+        d="M70 45H75C79.4183 45 83 48.5817 83 53C83 57.4183 79.4183 61 75 61H70"
+        stroke="#334155"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+      {/* 湯気「A」 */}
+      <path
+        d="M40 25L45 15L50 25M42 21H48"
+        stroke="#2ecc71"
+        strokeWidth="5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* 湯気「C」 */}
+      <path
+        d="M65 25C60 25 58 20 58 17.5C58 15 60 10 65 10"
+        stroke="#2ecc71"
+        strokeWidth="5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { UserIdForm } from "./UserIdForm";
+import { CoffeeACIcon } from "./CoffeeACIcon";
 
 interface Props {
   userId: string;
@@ -28,8 +29,13 @@ export function Header({ userId, onChangeUserId, onReset }: Props) {
     <header className="border-b bg-background sticky top-0 z-10">
       <div className="mx-auto max-w-5xl flex items-center justify-between px-4 h-14">
         <div className="flex items-center gap-4">
-          <Link href="/" className="text-xl font-bold tracking-tight hover:opacity-80 shrink-0">
-            Next-AC
+          <Link href="/" className="flex items-center gap-2 hover:opacity-80 shrink-0">
+            <CoffeeACIcon size={28} />
+            <span className="text-xl font-bold tracking-tight">
+              <span className="text-slate-800 dark:text-slate-100">Next</span>
+              <span className="text-slate-400 mx-0.5">-</span>
+              <span className="text-[#2ecc71]">AC</span>
+            </span>
           </Link>
           <Link
             href="/guide"


### PR DESCRIPTION
## Summary

- SVG ベースの `CoffeeACIcon` コンポーネントを新規作成（コーヒーカップ + 湯気「AC」）
- ヘッダーのロゴテキストをアイコン付きに変更
- トップページのタイトルをアイコン付きに変更し、"AC" を緑色で強調

## Test plan

- [x] ライト・ダークモード両方でアイコンの表示を確認
- [x] ヘッダー・トップページでアイコンが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)