### PR TITLE
enhance: フッターにバージョン表示を追加、Logテーブルのスクロール改善

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { version } from "../../package.json";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,7 +29,12 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          {children}
+          <footer className="fixed bottom-2 right-3 text-xs text-muted-foreground/40 pointer-events-none">
+            v{version}
+          </footer>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -97,7 +97,7 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="h-screen overflow-hidden bg-background">
       <Header
         userId={userId}
         onChangeUserId={handleSetUserId}

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -49,7 +49,8 @@ function ContestTable({ rows, ascending, onToggleSort, onFocus }: {
   const sorted = ascending ? [...rows].reverse() : rows;
 
   return (
-    <div className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-11.5rem)]">
+    <div className="overflow-x-auto">
+      {/* 固定ヘッダー */}
       <table className="w-full text-sm border-collapse table-fixed">
         <thead>
           <tr className="border-b">
@@ -69,19 +70,24 @@ function ContestTable({ rows, ascending, onToggleSort, onFocus }: {
             ))}
           </tr>
         </thead>
-        <tbody>
-          {sorted.map(({ contestId, cols }) => (
-            <tr key={contestId} className="border-b hover:bg-muted/30">
-              <td className="p-2 font-mono text-xs text-muted-foreground">
-                {contestId.toUpperCase()}
-              </td>
-              <ProblemCell problem={cols.A} onFocus={onFocus} />
-              <ProblemCell problem={cols.B} onFocus={onFocus} />
-              <ProblemCell problem={cols.C} onFocus={onFocus} />
-            </tr>
-          ))}
-        </tbody>
       </table>
+      {/* スクロール対象のbody */}
+      <div className="overflow-y-auto max-h-[calc(100vh-14rem)]">
+        <table className="w-full text-sm border-collapse table-fixed">
+          <tbody>
+            {sorted.map(({ contestId, cols }) => (
+              <tr key={contestId} className="border-b hover:bg-muted/30">
+                <td className="p-2 font-mono text-xs text-muted-foreground">
+                  {contestId.toUpperCase()}
+                </td>
+                <ProblemCell problem={cols.A} onFocus={onFocus} />
+                <ProblemCell problem={cols.B} onFocus={onFocus} />
+                <ProblemCell problem={cols.C} onFocus={onFocus} />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -49,10 +49,9 @@ function ContestTable({ rows, ascending, onToggleSort, onFocus }: {
   const sorted = ascending ? [...rows].reverse() : rows;
 
   return (
-    <div className="overflow-x-auto">
-      {/* 固定ヘッダー */}
+    <div className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-11.5rem)]">
       <table className="w-full text-sm border-collapse table-fixed">
-        <thead>
+        <thead className="sticky top-0 bg-background">
           <tr className="border-b">
             <th className="p-2 text-left font-medium text-muted-foreground">
               <button
@@ -70,24 +69,19 @@ function ContestTable({ rows, ascending, onToggleSort, onFocus }: {
             ))}
           </tr>
         </thead>
+        <tbody>
+          {sorted.map(({ contestId, cols }) => (
+            <tr key={contestId} className="border-b hover:bg-muted/30">
+              <td className="p-2 font-mono text-xs text-muted-foreground">
+                {contestId.toUpperCase()}
+              </td>
+              <ProblemCell problem={cols.A} onFocus={onFocus} />
+              <ProblemCell problem={cols.B} onFocus={onFocus} />
+              <ProblemCell problem={cols.C} onFocus={onFocus} />
+            </tr>
+          ))}
+        </tbody>
       </table>
-      {/* スクロール対象のbody */}
-      <div className="overflow-y-auto max-h-[calc(100vh-14rem)]">
-        <table className="w-full text-sm border-collapse table-fixed">
-          <tbody>
-            {sorted.map(({ contestId, cols }) => (
-              <tr key={contestId} className="border-b hover:bg-muted/30">
-                <td className="p-2 font-mono text-xs text-muted-foreground">
-                  {contestId.toUpperCase()}
-                </td>
-                <ProblemCell problem={cols.A} onFocus={onFocus} />
-                <ProblemCell problem={cols.B} onFocus={onFocus} />
-                <ProblemCell problem={cols.C} onFocus={onFocus} />
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
     </div>
   );
 }

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -49,7 +49,7 @@ function ContestTable({ rows, ascending, onToggleSort, onFocus }: {
   const sorted = ascending ? [...rows].reverse() : rows;
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto overflow-y-auto max-h-[calc(100vh-11.5rem)]">
       <table className="w-full text-sm border-collapse table-fixed">
         <thead>
           <tr className="border-b">


### PR DESCRIPTION
## Summary

- 全ページ共通のフッターにバージョン番号を表示（`package.json` から自動取得、fixed右下）
- ページ自体のスクロールを廃止し、Logテーブルのみスクロールする構造に変更
- テーブルの高さをフッターに合わせてぴったり設定

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)